### PR TITLE
fix results files not found bug

### DIFF
--- a/typical_atypical_classifier.py
+++ b/typical_atypical_classifier.py
@@ -331,7 +331,8 @@ class TypicalClassifier:
 
 
 def write_csv(path, header, rows):
-    with open(path, 'w') as csvfile:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w+') as csvfile:
         csvwriter = csv.writer(csvfile)
         csvwriter.writerow(header)
         csvwriter.writerows(rows)


### PR DESCRIPTION
I was working with the code and realized that the "results" directory (for when `write_all_csv_results` is called) and the files inside it are not created if they don't exist. I made a quick modification to fix that. I'm making this PR in case you think it's something to include.
